### PR TITLE
Migrate backend to remote state

### DIFF
--- a/bootstrap/backend/main.tf
+++ b/bootstrap/backend/main.tf
@@ -2,6 +2,10 @@ terraform {
   # We need this for S3-native state locking
   required_version = ">= 1.10.0"
 
+  backend "s3" {
+    key = "bootstrap/backend/terraform.tfstate"
+  }
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/bootstrap/env-backends/main.tf
+++ b/bootstrap/env-backends/main.tf
@@ -2,8 +2,9 @@ terraform {
   # We need this for S3-native state locking
   required_version = ">= 1.10.0"
 
-  # Values provided during init
-  backend "s3" {}
+  backend "s3" {
+    key = "bootstrap/env-backends/terraform.tfstate"
+  }
 
   required_providers {
     aws = {

--- a/bootstrap/organization/main.tf
+++ b/bootstrap/organization/main.tf
@@ -1,6 +1,7 @@
 terraform {
-  # Values provided during init
-  backend "s3" {}
+  backend "s3" {
+    key = "bootstrap/organization/terraform.tfstate"
+  }
 
   required_providers {
     aws = {


### PR DESCRIPTION
This is possible because we're allowed to [store an S3 bucket's state file within itself](https://discuss.hashicorp.com/t/is-it-possible-to-create-s3-bucket-and-store-the-statefile-in-the-same-s3-bucket-backend/3042/2), as long as it is created normally first and the local state is migrated afterward.